### PR TITLE
refactor: rename plugin to include prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# plugin-translations
+# api-plugin-translations
 
-[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/plugin-translations.svg)](https://www.npmjs.com/package/@reactioncommerce/plugin-translations)
-[![CircleCI](https://circleci.com/gh/reactioncommerce/plugin-translations.svg?style=svg)](https://circleci.com/gh/reactioncommerce/plugin-translations)
+[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/api-plugin-translations.svg)](https://www.npmjs.com/package/@reactioncommerce/api-plugin-translations)
+[![CircleCI](https://circleci.com/gh/reactioncommerce/api-plugin-translations.svg?style=svg)](https://circleci.com/gh/reactioncommerce/api-plugin-translations)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Summary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-translations",
+  "name": "@reactioncommerce/api-plugin-translations",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-translations",
+  "name": "@reactioncommerce/api-plugin-translations",
   "description": "Translations plugin for the Reaction API",
   "version": "0.0.0-development",
   "main": "index.js",
@@ -7,12 +7,12 @@
   "engines": {
     "node": ">=12.14.1"
   },
-  "homepage": "https://github.com/reactioncommerce/plugin-translations",
-  "url": "https://github.com/reactioncommerce/plugin-translations",
+  "homepage": "https://github.com/reactioncommerce/api-plugin-translations",
+  "url": "https://github.com/reactioncommerce/api-plugin-translations",
   "email": "engineering@reactioncommerce.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactioncommerce/plugin-translations.git"
+    "url": "git+https://github.com/reactioncommerce/api-plugin-translations.git"
   },
   "author": {
     "name": "Reaction Commerce",
@@ -21,7 +21,7 @@
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/reactioncommerce/plugin-translations/issues"
+    "url": "https://github.com/reactioncommerce/api-plugin-translations/issues"
   },
   "sideEffects": false,
   "dependencies": {


### PR DESCRIPTION
Resolves #3 

Rename this plugin from `plugin-translations` to `api-plugin-translations`.

This will create a new npm package with a v1.0.0, and this new package will need to be installed in reaction core.

We also need to deprecate the existing npm package.